### PR TITLE
adding the docker dependinces for roboticstoolbox

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,8 @@ RUN pip3 install pydantic==1.10.9
 RUN pip3 install odpslides
 RUN pip3 install pyserial
 
+RUN pip3 install roboticstoolbox-python
+
 USER root
 RUN apt update && apt install -y \
     libboost-dev \
@@ -89,7 +91,8 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     ros-humble-mapviz-plugins \
     ros-humble-tile-map \
     ros-humble-multires-image \
-    ros-humble-rosapi
+    ros-humble-rosapi; \
+    fi
 USER marsrover
 
 # Colorized ROS 2 logging output

--- a/mars_ws/src/home_gui/package.xml
+++ b/mars_ws/src/home_gui/package.xml
@@ -9,6 +9,7 @@
 
 
   <build_depend>rover_msgs</build_depend>
+  <exec_depend>roboticstoolbox-python</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This adds the necessary lines to get roboticstoolbox installed in the docker image. This is for the keyboard autonomy feature