### PR TITLE
Moved Nano to usb devices launch

### DIFF
--- a/mars_ws/src/start/launch/rover_common_launch.py
+++ b/mars_ws/src/start/launch/rover_common_launch.py
@@ -30,10 +30,11 @@ def generate_launch_description():
 
         # NOTE: Comment not pushed because it is a temporary fix
         # Peripherals
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(os.path.join( 
-                peripherals_dir, 'launch', 'peripherals.launch.py'))
-        ),
+        # Moved to USB devices launch file
+        # IncludeLaunchDescription(
+        #     PythonLaunchDescriptionSource(os.path.join( 
+        #         peripherals_dir, 'launch', 'peripherals.launch.py'))
+        # ),
 
         # Heartbeat
         # IncludeLaunchDescription(

--- a/mars_ws/src/start/launch/rover_usb_devices_launch.py
+++ b/mars_ws/src/start/launch/rover_usb_devices_launch.py
@@ -16,6 +16,7 @@ import os
 def generate_launch_description():
     # Start USB devices launch files specific to the Autonomy Task on the rover
     cam_config_path = os.path.join(get_package_share_directory('start'), 'config', 'cam_config', 'head_cam_params.yaml')
+    peripherals_dir = get_package_share_directory('peripherals')
 
     include_mobility = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(os.path.join(
@@ -73,11 +74,15 @@ def generate_launch_description():
             ]
         )
 
+    include_nano = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(os.path.join( 
+                peripherals_dir, 'launch', 'peripherals.launch.py'))
+        )
 
 
     return LaunchDescription([
         include_mobility,
         include_gps,
-        include_usb_cam
-        
+        include_usb_cam,
+        include_nano,
     ])


### PR DESCRIPTION
Add the nano launch file to the usb devices launch file so that we can keep the state machine and everything running when we reset the USB devices

- [x] This code builds and runs correctly in the Docker container on my own computer.
- [x] This code builds and runs correctly in the Docker container on the rover.
- [x] I have added any new dependencies to the Dockerfile.